### PR TITLE
Fix ParseError / Syntax Error

### DIFF
--- a/BusServiceProvider.php
+++ b/BusServiceProvider.php
@@ -47,7 +47,7 @@ class BusServiceProvider extends ServiceProvider implements DeferrableProvider
             return new DatabaseBatchRepository(
                 $app->make(BatchFactory::class),
                 $app->make('db')->connection(config('queue.batching.database')),
-                config('queue.batching.table', 'job_batches'),
+                config('queue.batching.table', 'job_batches')
             );
         });
     }


### PR DESCRIPTION
There was a comma too much on line 51, so it caused a ParseError whenever Laravel loads this class.