### PR TITLE
Delay method also accepts an array.

### DIFF
--- a/Queueable.php
+++ b/Queueable.php
@@ -47,7 +47,7 @@ trait Queueable
     /**
      * The number of seconds before the job should be made available.
      *
-     * @var \DateTimeInterface|\DateInterval|int|null
+     * @var \DateTimeInterface|\DateInterval|array|int|null
      */
     public $delay;
 
@@ -129,7 +129,7 @@ trait Queueable
     /**
      * Set the desired delay for the job.
      *
-     * @param  \DateTimeInterface|\DateInterval|int|null  $delay
+     * @var \DateTimeInterface|\DateInterval|array|int|null
      * @return $this
      */
     public function delay($delay)

--- a/Queueable.php
+++ b/Queueable.php
@@ -129,7 +129,7 @@ trait Queueable
     /**
      * Set the desired delay for the job.
      *
-     * @var \DateTimeInterface|\DateInterval|array|int|null
+     * @param \DateTimeInterface|\DateInterval|array|int|null
      * @return $this
      */
     public function delay($delay)

--- a/Queueable.php
+++ b/Queueable.php
@@ -129,7 +129,7 @@ trait Queueable
     /**
      * Set the desired delay for the job.
      *
-     * @param \DateTimeInterface|\DateInterval|array|int|null
+     * @param \DateTimeInterface|\DateInterval|array|int|null $delay
      * @return $this
      */
     public function delay($delay)


### PR DESCRIPTION
Changes the docblock so  `array` is an accepted parameter type on `delay($delay)` method on the `Queueable` trait.
According to documentation: https://laravel.com/docs/8.x/notifications#queueing-notifications

```php
$user->notify((new InvoicePaid($invoice))->delay([
    'mail' => now()->addMinutes(5),
    'sms' => now()->addMinutes(10),
]));
```

This is already fixed in 9.x but not present in the 8.x branch.